### PR TITLE
Optimize Sprintfln by using '\n' instead of fmt.Sprintln()

### DIFF
--- a/fmt.go
+++ b/fmt.go
@@ -29,7 +29,7 @@ func Sprintf(format string, params map[string]interface{}) string {
 // Sprintfln support named format
 func Sprintfln(format string, params map[string]interface{}) string {
 	f, p := parse(format, params)
-	return fmt.Sprintf(f, p...) + fmt.Sprintln()
+	return fmt.Sprintf(f+"\n", p...)
 }
 
 func parse(format string, params map[string]interface{}) (string, []interface{}) {

--- a/fmt_test.go
+++ b/fmt_test.go
@@ -92,3 +92,15 @@ func TestSprintfFloatsWithPrecision(t *testing.T) {
 		t.Errorf("result should be (%v) but is (%v)", expectedresult, s)
 	}
 }
+
+func BenchmarkSprintln(b *testing.B) {
+	pat := "%<brother>s loves %<sister>s. %<sister>s also loves %<brother>s."
+	params := map[string]interface{}{
+		"sister":  "Susan",
+		"brother": "Louis",
+	}
+
+	for i := 0; i < b.N; i++ {
+		_ = Sprintfln(pat, params)
+	}
+}


### PR DESCRIPTION
The benchmark result is:

benchmark               old ns/op     new ns/op     delta
BenchmarkSprintln       2939          2859          -2.72%
BenchmarkSprintln-2     2963          2904          -1.99%
BenchmarkSprintln-4     2994          2937          -1.90%
BenchmarkSprintln-8     3020          2920          -3.31%