### PR TITLE
Optimize Sprintfln() by used fixed allocate slice instead of append

### DIFF
--- a/fmt.go
+++ b/fmt.go
@@ -34,9 +34,9 @@ func Sprintfln(format string, params map[string]interface{}) string {
 
 func parse(format string, params map[string]interface{}) (string, []interface{}) {
 	f, n := reformat(format)
-	var p []interface{}
-	for _, v := range n {
-		p = append(p, params[v])
+	p := make([]interface{}, len(n))
+	for i, v := range n {
+		p[i] = params[v]
 	}
 	return f, p
 }


### PR DESCRIPTION
The benchmark result compare to master branch is:

benchmark               old ns/op     new ns/op     delta
BenchmarkSprintln       2904          2760          -4.96%
BenchmarkSprintln-2     2928          2775          -5.23%
BenchmarkSprintln-4     2937          2778          -5.41%
BenchmarkSprintln-8     2919          2778          -4.83%

benchmark               old allocs     new allocs     delta
BenchmarkSprintln       20             18             -10.00%
BenchmarkSprintln-2     20             18             -10.00%
BenchmarkSprintln-4     20             18             -10.00%
BenchmarkSprintln-8     20             18             -10.00%

benchmark               old bytes     new bytes     delta
BenchmarkSprintln       985           936           -4.97%
BenchmarkSprintln-2     988           939           -4.96%
BenchmarkSprintln-4     988           939           -4.96%
BenchmarkSprintln-8     990           939           -5.15%