### PR TITLE
Add the ability to format structures

### DIFF
--- a/fmt.go
+++ b/fmt.go
@@ -2,33 +2,35 @@ package format
 
 import (
 	"fmt"
+	"github.com/mitchellh/mapstructure"
 	"regexp"
 )
 
 var re = regexp.MustCompile("%<([a-zA-Z0-9_]+)>[.0-9]*[xsvTtbcdoqXxUeEfFgGp]")
 
 // Printf support named format
-func Printf(format string, params map[string]interface{}) {
-	f, p := parse(format, params)
+func Printf(format string, params interface{}) {
+	f, p := parse(format, GetMapValues(params))
 	fmt.Printf(f, p...)
 }
 
 // Printfln support named format
-func Printfln(format string, params map[string]interface{}) {
-	f, p := parse(format, params)
+func Printfln(format string, params interface{}) {
+	f, p := parse(format, GetMapValues(params))
 	fmt.Printf(f, p...)
 	fmt.Println()
 }
 
 // Sprintf support named format
-func Sprintf(format string, params map[string]interface{}) string {
-	f, p := parse(format, params)
+func Sprintf(format string, params interface{}) string {
+	values := GetMapValues(params)
+	f, p := parse(format, values)
 	return fmt.Sprintf(f, p...)
 }
 
 // Sprintfln support named format
-func Sprintfln(format string, params map[string]interface{}) string {
-	f, p := parse(format, params)
+func Sprintfln(format string, params interface{}) string {
+	f, p := parse(format, GetMapValues(params))
 	return fmt.Sprintf(f+"\n", p...)
 }
 
@@ -60,4 +62,55 @@ func reformat(f string) (string, []string) {
 	}
 
 	return out, ord
+}
+
+// GetMapValues convert interface to map[string]interface{}
+func GetMapValues(input interface{}) map[string]interface{} {
+	var output = map[string]interface{}{}
+	var err = mapstructure.WeakDecode(input, &output)
+
+	if err != nil {
+		panic(err)
+	}
+
+	// Get values form pointers into map
+	for k, val := range output {
+		switch typedValue := val.(type) {
+		case *float64:
+		case *float32:
+		case *int64:
+		case *int16:
+		case *int:
+			if typedValue == nil {
+				output[k] = 0
+			} else {
+				output[k] = *typedValue
+			}
+			break
+		case *string:
+			if typedValue == nil {
+				output[k] = ""
+			} else {
+				output[k] = *typedValue
+			}
+			break
+		case *bool:
+			if typedValue == nil || !*typedValue {
+				output[k] = "false"
+			} else {
+				output[k] = "true"
+			}
+			break
+		case bool:
+			if typedValue {
+				output[k] = "true"
+			} else {
+				output[k] = "false"
+			}
+			break
+		default:
+			output[k] = val
+		}
+	}
+	return output
 }

--- a/fmt_test.go
+++ b/fmt_test.go
@@ -62,6 +62,23 @@ func TestSprintf(t *testing.T) {
 	}
 }
 
+func TestSprintfStruct(t *testing.T) {
+	pat := "%<Brother>s loves %<Sister>s. %<Sister>s also loves %<Brother>s."
+	params := struct {
+		Brother string
+		Sister  string
+	}{
+		Brother: "Louis",
+		Sister:  "Susan",
+	}
+
+	s := Sprintf(pat, params)
+
+	if s != "Louis loves Susan. Susan also loves Louis." {
+		t.Errorf("result should be Louis loves Susan. Susan also love Louis. but %v", s)
+	}
+}
+
 func TestSprintfln(t *testing.T) {
 	pat := "%<brother>s loves %<sister>s. %<sister>s also loves %<brother>s."
 	params := map[string]interface{}{

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/chonla/format
 
 go 1.17
+
+require github.com/mitchellh/mapstructure v1.5.0


### PR DESCRIPTION
In my case, I needed to pass structures and since there was no support, I extended the library.

Supported structure properties types: 

* float64, 
* float32,
* int
* int64
* int16
* string
* bool

... and their pointers.

If the sub-type is not supported, it is passed as is.  

